### PR TITLE
Update step_mark_as_template.go to resolve #224

### DIFF
--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -27,6 +27,9 @@ type stepMarkAsTemplate struct {
 
 func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepMarkAsTemplate {
 	remoteFolder := "Discovered virtual machine"
+	if p.config.Folder != nil {
+		remoteFolder = p.config.Folder
+	}
 	vmname := artifact.Id()
 
 	if artifact.BuilderId() == vsphere.BuilderId {

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -27,7 +27,8 @@ type stepMarkAsTemplate struct {
 
 func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepMarkAsTemplate {
 	remoteFolder := "Discovered virtual machine"
-	if p.config.Folder != nil {
+	//if post-processor config folder is not null, use the folder as remoteFolder
+	if p.config.Folder != "" {
 		remoteFolder = p.config.Folder
 	}
 	vmname := artifact.Id()


### PR DESCRIPTION
Use the post-processor config folder if defined in the packer config, otherwise default it to "Discovered virtual machine"

This PR is to address the issue
https://github.com/hashicorp/packer-plugin-vsphere/issues/224

Closes #224

